### PR TITLE
Allow brackets in URLs

### DIFF
--- a/sluggle.pl
+++ b/sluggle.pl
@@ -447,9 +447,9 @@ sub irc_public {
     # Shorten links and return title
     } elsif ( (my @requests) = $what =~ /
         \b
-        (https?:\/\/[^ \(\)\[\]]+)
+        (https?:\/\/[^\s]+)
         (?:
-            [\s\(\)\[\]]
+            [\s]
             |
             $
         )


### PR DESCRIPTION
Trivial change to allow brackets in URLs, since brackets do appear in URLs sometimes!