### PR TITLE
Support Twitter frontend for status titles

### DIFF
--- a/conf/template.conf
+++ b/conf/template.conf
@@ -29,4 +29,4 @@ wolfram_appid XXXXXX-XXXXXXXXXX
 
 # Twitter frontend. Twitter is hostile to scraping, so instead use a third
 # party frontend to get tweet information.
-twitter_frontend    "https://nitter.nixnet.services"
+twitter_frontend    "https://nitter.nixnet.services/"

--- a/conf/template.conf
+++ b/conf/template.conf
@@ -26,3 +26,7 @@ key         "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 # Wolfram
 wolfram_appid XXXXXX-XXXXXXXXXX
+
+# Twitter frontend. Twitter is hostile to scraping, so instead use a third
+# party frontend to get tweet information.
+twitter_frontend    "https://nitter.nixnet.services"

--- a/lib/config.pm
+++ b/lib/config.pm
@@ -36,7 +36,7 @@ sub get_config {
 # Arguments:
 # - Reference to Config::Simple object.
 # Returns:
-# - Same Config::Simple refernece with any changes.
+# - Same Config::Simple reference with any changes.
 sub validate_config {
     my ($conf) = @_;
 

--- a/lib/config.pm
+++ b/lib/config.pm
@@ -3,9 +3,12 @@ package config;
 use strict;
 use Exporter;
 use Config::Simple;
+use URI;
+use Carp;
 
 my @functions = qw(
     get_config
+    validate_config
     add_channel
     remove_channel
     list_bots
@@ -25,6 +28,37 @@ our %EXPORT_TAGS = (
 sub get_config {
     my $file = shift;
     my $conf = new Config::Simple($file);
+
+    return $conf;
+}
+
+# Check our configuration is sensible and normalise things where possible.
+# Arguments:
+# - Reference to Config::Simple object.
+# Returns:
+# - Same Config::Simple refernece with any changes.
+sub validate_config {
+    my ($conf) = @_;
+
+    if (defined $conf->param('twitter_frontend')) {
+        my $fe_uri = URI->new($conf->param('twitter_frontend'));
+
+        if (not defined $fe_uri or not $fe_uri->has_recognized_scheme) {
+            croak "twitter_frontend '" . $conf->param('twitter_frontend')
+                . "' doesn't look like a valid URI";
+        }
+
+        if ($fe_uri->scheme !~ /^https?$/) {
+            croak "twitter_frontend scheme must be 'http' or 'https'";
+        }
+
+        if ($fe_uri->path !~ m|/$|) {
+            carp "Appending '/' to your twitter_frontend '"
+                . $fe_uri->as_string . "'";
+            $fe_uri->path($fe_uri->path . '/');
+            $conf->param('twitter_frontend', $fe_uri->as_string);
+        }
+    }
 
     return $conf;
 }

--- a/sluggle.pl
+++ b/sluggle.pl
@@ -40,6 +40,7 @@ use vars qw( $CONF $LAG $REC );
 
 if ( (defined $ARGV[0]) and (-r $ARGV[0]) ) {
     $CONF = config::get_config($ARGV[0]);
+    $CONF = config::validate_config($CONF);
 } else {
     print "USAGE: sluggle.pl sluggle.conf\n";
     exit;
@@ -537,8 +538,19 @@ sub find {
             return $error;
         }
 
-        $url     = $request;
-        $title   = get_data($request);
+        $url = $request;
+
+        # If a Twitter frontend has been configured then just get the title
+        # (which will be the tweet text) from that frontend, as Twitter is
+        # hostile to non-JS bots and makes it hard to get any other way.
+        if ($url =~ m|^https?://twitter\.com/([^\s]+/status/[0-9]+)|i
+                and defined $CONF->param('twitter_frontend')) {
+            my $frontend = $CONF->param('twitter_frontend');
+            $title = get_data($frontend . $1);
+        } else {
+            $title = get_data($request);
+        }
+
         $shorten = shorten($url);
         $wot     = wot::lookup($CONF, $url);
 


### PR DESCRIPTION
Allow title requests for Twitter statuses (e.g. https://twitter.com/SomeUser/status/123456789) to be made against a _Twitter frontend_ site instead.

Such frontend sites can be provided by the [nitter](https://github.com/zedeus/nitter) software, but we can just use an already-existing instance of nitter such as https://nitter.nixnet.services/.

So, in the configuration if we add:

```
twitter_frontend "https://nitter.nixnet.services/"
```

…then title requests for Twitter statuses will work.